### PR TITLE
Fix CI: resolve xunit runner version mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Build — TenantKit.Demo (sample)
         run: dotnet build samples/TenantKit.Demo --configuration Release --no-restore
 
+      - name: Build — TenantKit.Tests
+        run: dotnet build tests/TenantKit.Tests --configuration Release --no-restore
+
       - name: Test
         run: dotnet test --configuration Release --no-build --verbosity normal --logger "trx;LogFileName=test-results.trx"
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="FluentAssertions" Version="8.8.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.3" />


### PR DESCRIPTION
## Summary
- **Downgrade `xunit.runner.visualstudio`** from 3.1.5 to 2.8.2 to fix version mismatch with `xunit` 2.9.3. The v3 runner uses Microsoft Testing Platform, which is incompatible with xunit v2 and rejects the test DLL argument passed by VSTest, causing `The argument ...TenantKit.Tests.dll is invalid`.
- **Add explicit build step** for the test project in CI, since it was not being built before the `dotnet test --no-build` step.

## Test plan
- [x] Verified locally: all 24 tests pass with `dotnet test --configuration Release --no-build`
- [ ] CI should pass on this PR