### PR TITLE
Integrate TheAppManager module system

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,14 +2,15 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Testing -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageVersion Include="TheAppManager" Version="2.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="coverlet.collector" Version="8.0.0" />
     <PackageVersion Include="FluentAssertions" Version="8.9.0" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.5" />
   </ItemGroup>
 </Project>

--- a/samples/TenantKit.Demo/Modules/EndpointsModule.cs
+++ b/samples/TenantKit.Demo/Modules/EndpointsModule.cs
@@ -1,0 +1,87 @@
+using TenantKit.Core;
+using TheAppManager.Modules;
+
+namespace TenantKit.Demo.Modules;
+
+/// <summary>
+/// Maps all API endpoints for the TenantKit Demo.
+/// </summary>
+public sealed class EndpointsModule : IAppModule
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+    }
+
+    public void ConfigureMiddleware(WebApplication app)
+    {
+    }
+
+    public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        // Public endpoint — no tenant required
+        endpoints.MapGet("/", () => new
+        {
+            service = "TenantKit Demo API",
+            version = "0.1.0-poc",
+            docs = "Pass X-Tenant-Id header or ?tenant= query param to identify your tenant"
+        });
+
+        // Tenant-aware endpoint
+        endpoints.MapGet("/info", (ITenantContext ctx) =>
+        {
+            if (!ctx.HasTenant)
+                return Results.Ok(new { tenant = (string?)null, message = "Anonymous request — no tenant resolved" });
+
+            var t = ctx.Current!;
+            return Results.Ok(new
+            {
+                id       = t.Id,
+                name     = t.Name,
+                metadata = ((Tenant)t).Metadata
+            });
+        });
+
+        // Simulated per-tenant data endpoint
+        endpoints.MapGet("/data", (ITenantContext ctx) =>
+        {
+            if (!ctx.HasTenant)
+                return Results.Unauthorized();
+
+            // In a real app: query YOUR database filtered by tenant.Id
+            var rows = ctx.Current!.Id switch
+            {
+                "acme"    => new[] { "Widget A", "Widget B", "Widget C" },
+                "globex"  => new[] { "Product X", "Product Y" },
+                "initech" => new[] { "Item Alpha" },
+                _         => Array.Empty<string>()
+            };
+
+            return Results.Ok(new { tenant = ctx.Current.Id, records = rows, count = rows.Length });
+        });
+
+        // Feature flag endpoint (reads from tenant metadata)
+        endpoints.MapGet("/features", (ITenantContext ctx) =>
+        {
+            if (!ctx.HasTenant)
+                return Results.Unauthorized();
+
+            var plan = ((Tenant)ctx.Current!).Metadata?.GetValueOrDefault("plan", "free") ?? "free";
+
+            return Results.Ok(new
+            {
+                tenant   = ctx.Current.Id,
+                plan,
+                features = plan switch
+                {
+                    "enterprise"   => new[] { "SSO", "Audit Logs", "Custom Domain", "SLA 99.99%", "Dedicated Support" },
+                    "professional" => new[] { "SSO", "Audit Logs", "Custom Domain" },
+                    "starter"      => new[] { "Standard Support" },
+                    _              => new[] { "Limited Access" }
+                }
+            });
+        });
+
+        // Health check (tenant-agnostic)
+        endpoints.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
+    }
+}

--- a/samples/TenantKit.Demo/Modules/TenantKitModule.cs
+++ b/samples/TenantKit.Demo/Modules/TenantKitModule.cs
@@ -1,0 +1,52 @@
+using TenantKit.AspNetCore;
+using TenantKit.Core;
+using TheAppManager.Modules;
+
+namespace TenantKit.Demo.Modules;
+
+/// <summary>
+/// Configures TenantKit services and middleware.
+/// </summary>
+public sealed class TenantKitModule : IAppModule
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddTenantKit(tk => tk
+            // Strategy 1: check header first
+            .UseHeaderResolver("X-Tenant-Id")
+            // Strategy 2: fall back to query string (good for dev/testing)
+            .UseQueryStringResolver("tenant")
+            // Seed tenants (swap this for .WithStore<MyDbTenantStore>() in production)
+            .WithInMemoryStore(tenants =>
+            {
+                tenants.Add(Tenant.Create("acme", "Acme Corp", new Dictionary<string, string>
+                {
+                    ["plan"]   = "enterprise",
+                    ["region"] = "eu-west-1",
+                    ["theme"]  = "dark"
+                }));
+                tenants.Add(Tenant.Create("globex", "Globex Inc", new Dictionary<string, string>
+                {
+                    ["plan"]   = "starter",
+                    ["region"] = "us-east-1",
+                    ["theme"]  = "light"
+                }));
+                tenants.Add(Tenant.Create("initech", "Initech Ltd", new Dictionary<string, string>
+                {
+                    ["plan"]   = "professional",
+                    ["region"] = "ap-southeast-1",
+                    ["theme"]  = "system"
+                }));
+            }));
+    }
+
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        // TenantKit middleware — place it early
+        app.UseTenantKit();
+    }
+
+    public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+    {
+    }
+}

--- a/samples/TenantKit.Demo/Program.cs
+++ b/samples/TenantKit.Demo/Program.cs
@@ -1,117 +1,17 @@
-using TenantKit.AspNetCore;
-using TenantKit.Core;
-
-var builder = WebApplication.CreateBuilder(args);
+using TenantKit.Demo.Modules;
+using TheAppManager.Startup;
 
 // ──────────────────────────────────────────────────────────────────────────────
-// TenantKit configuration
+// TenantKit Demo — powered by TheAppManager module system
 // Try it with:
 //   curl http://localhost:5000/info -H "X-Tenant-Id: acme"
 //   curl "http://localhost:5000/info?tenant=globex"
 //   curl http://localhost:5000/info          (no tenant — public)
 // ──────────────────────────────────────────────────────────────────────────────
 
-builder.Services.AddTenantKit(tk => tk
-    // Strategy 1: check header first
-    .UseHeaderResolver("X-Tenant-Id")
-    // Strategy 2: fall back to query string (good for dev/testing)
-    .UseQueryStringResolver("tenant")
-    // Seed tenants (swap this for .WithStore<MyDbTenantStore>() in production)
-    .WithInMemoryStore(tenants =>
-    {
-        tenants.Add(Tenant.Create("acme", "Acme Corp", new Dictionary<string, string>
-        {
-            ["plan"]   = "enterprise",
-            ["region"] = "eu-west-1",
-            ["theme"]  = "dark"
-        }));
-        tenants.Add(Tenant.Create("globex", "Globex Inc", new Dictionary<string, string>
-        {
-            ["plan"]   = "starter",
-            ["region"] = "us-east-1",
-            ["theme"]  = "light"
-        }));
-        tenants.Add(Tenant.Create("initech", "Initech Ltd", new Dictionary<string, string>
-        {
-            ["plan"]   = "professional",
-            ["region"] = "ap-southeast-1",
-            ["theme"]  = "system"
-        }));
-    }));
-
-var app = builder.Build();
-
-// TenantKit middleware — place it early
-app.UseTenantKit();
-
-// ──────────────────────────────────────────────────────────────────────────────
-// Endpoints
-// ──────────────────────────────────────────────────────────────────────────────
-
-// Public endpoint — no tenant required
-app.MapGet("/", () => new
+AppManager.Start(args, modules =>
 {
-    service = "TenantKit Demo API",
-    version = "0.1.0-poc",
-    docs = "Pass X-Tenant-Id header or ?tenant= query param to identify your tenant"
+    modules
+        .Add<TenantKitModule>()
+        .Add<EndpointsModule>();
 });
-
-// Tenant-aware endpoint
-app.MapGet("/info", (ITenantContext ctx) =>
-{
-    if (!ctx.HasTenant)
-        return Results.Ok(new { tenant = (string?)null, message = "Anonymous request — no tenant resolved" });
-
-    var t = ctx.Current!;
-    return Results.Ok(new
-    {
-        id       = t.Id,
-        name     = t.Name,
-        metadata = ((TenantKit.Core.Tenant)t).Metadata
-    });
-});
-
-// Simulated per-tenant data endpoint
-app.MapGet("/data", (ITenantContext ctx) =>
-{
-    if (!ctx.HasTenant)
-        return Results.Unauthorized();
-
-    // In a real app: query YOUR database filtered by tenant.Id
-    var rows = ctx.Current!.Id switch
-    {
-        "acme"    => new[] { "Widget A", "Widget B", "Widget C" },
-        "globex"  => new[] { "Product X", "Product Y" },
-        "initech" => new[] { "Item Alpha" },
-        _         => Array.Empty<string>()
-    };
-
-    return Results.Ok(new { tenant = ctx.Current.Id, records = rows, count = rows.Length });
-});
-
-// Feature flag endpoint (reads from tenant metadata)
-app.MapGet("/features", (ITenantContext ctx) =>
-{
-    if (!ctx.HasTenant)
-        return Results.Unauthorized();
-
-    var plan = ((TenantKit.Core.Tenant)ctx.Current!).Metadata?.GetValueOrDefault("plan", "free") ?? "free";
-
-    return Results.Ok(new
-    {
-        tenant   = ctx.Current.Id,
-        plan,
-        features = plan switch
-        {
-            "enterprise"   => new[] { "SSO", "Audit Logs", "Custom Domain", "SLA 99.99%", "Dedicated Support" },
-            "professional" => new[] { "SSO", "Audit Logs", "Custom Domain" },
-            "starter"      => new[] { "Standard Support" },
-            _              => new[] { "Limited Access" }
-        }
-    });
-});
-
-// Health check (tenant-agnostic)
-app.MapGet("/health", () => Results.Ok(new { status = "healthy" }));
-
-app.Run();

--- a/samples/TenantKit.Demo/TenantKit.Demo.csproj
+++ b/samples/TenantKit.Demo/TenantKit.Demo.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\..\src\TenantKit.AspNetCore\TenantKit.AspNetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="TheAppManager" />
+  </ItemGroup>
+
 </Project>

--- a/tests/TenantKit.Tests/TenantKit.Tests.csproj
+++ b/tests/TenantKit.Tests/TenantKit.Tests.csproj
@@ -23,7 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Shouldly" Version="4.*" />
+    <PackageReference Include="Shouldly" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

- Integrate the [TheAppManager](https://www.nuget.org/packages/TheAppManager) v2.0.0 NuGet package into the `TenantKit.Demo` sample project
- Replace the monolithic `Program.cs` with composable `IAppModule` implementations:
  - **`TenantKitModule`** — registers TenantKit services (header/query resolvers, in-memory tenant store) and the `UseTenantKit()` middleware
  - **`EndpointsModule`** — maps all five API endpoints (`/`, `/info`, `/data`, `/features`, `/health`)
- Fix pre-existing `Shouldly` CPM version conflict in the test project

All existing business logic, service registrations, middleware, and endpoint mappings are preserved exactly as before — only the startup organization has changed.

## Test plan

- [x] `dotnet build` succeeds with zero warnings/errors
- [x] All 24 existing unit tests pass (`dotnet test`)
- [ ] Manual smoke test: `curl http://localhost:5000/info -H "X-Tenant-Id: acme"` returns tenant info
- [ ] Manual smoke test: `curl http://localhost:5000/health` returns healthy status